### PR TITLE
[add]mypage-directMessagePage-create

### DIFF
--- a/app/assets/stylesheets/user/mypage.scss
+++ b/app/assets/stylesheets/user/mypage.scss
@@ -36,7 +36,6 @@
 }
 
 .myPageBoxForm {
-  height: 200px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -407,8 +406,8 @@ ul.user-nav-bar li .active {
   align-items: center;
   margin: 0 auto;
   &__postCount {
-    font-size: 2vh;
-    padding: 1vh;
+    // font-size: 2vh;
+    // padding: 1vh;
   }
 }
 
@@ -625,6 +624,85 @@ ul.user-nav-bar li .active {
   }
 }
 
+// messageページ=========================================================================
+.directMessageUsers {
+  width: 100%;
+}
+.notification {
+  // height: 60vh;
+  overflow: scroll;
+}
+.dmUserBox {
+  height: 10vh;
+  // background-color: #222222;
+  background-color: rgba($color: #222222, $alpha: 0.8);
+  padding: 20px 20px;
+  display: flex;
+  align-items: center;
+  position: relative;
+  .showlink {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+}
+.dmUserBox:hover {
+  border: 1px solid #00bfff;
+}
+.dmUserInfomation {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  a {
+    color: #4682b4;
+  }
+  &__userAvater {
+    height: 50px;
+    width: auto;
+    font-size: 40px;
+    color: #ffffff;
+    border-radius: 3px;
+    box-shadow: 0 0 10px rgba(41, 41, 41, 0.2);
+    display: inline-block;
+    .avater {
+      height: 60px;
+      width: 60px;
+      border-radius: 50%;
+    }
+  }
+  &__username {
+    width: auto;
+    color: #4682b4;
+    margin-left: 5px;
+    display: inline-block;
+    z-index: 3;
+  }
+}
+.dmUserName {
+  font-size: 25px;
+}
+.dmUserName:hover {
+  color: #00bfff;
+  text-decoration: none;
+}
+.lastMessage {
+  font-size: 25px;
+  margin-left: 5vw;
+}
+.lastMessageUserName {
+  font-size: 1.5vh;
+  color: #999999;
+  margin-left: 1vw;
+}
+.lastMessageDate {
+  font-size: 1.2vh;
+  color: #999999;
+  position: absolute;
+  right: 5%;
+  bottom: 10%;
+}
 // グラフ===============================================================================
 .canvasContainer {
   width: 30vw;

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,6 +1,25 @@
 class RoomsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @current_user = current_user
+    @current_entries = @current_user.entries
+    myroom = []
+
+    # current_userのroom.idを格納
+    @current_entries.each do |entry|
+      myroom << entry.room.id
+    end
+
+    # 最新のメッセージのデータを取得する。
+    message = room.messages.order(updated_at: :desc).limit(1)
+    message = message[0]
+
+    # current_userと相手側のユーザーが格納されているレコードを探す処理
+    @another_entries = Entry.where(room_id: myroom).where.not(user_id: @current_user.id)
+    @new_entries = @another_entries.order(created_at: :desc)
+  end
+
   def create
     @room = Room.create
     @entry1 = Entry.create(:room_id => @room.id, :user_id => current_user.id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,6 +143,22 @@ class UsersController < ApplicationController
     gon.prefecture44 = @prefecture44
     gon.prefecture45 = @prefecture45
     gon.prefecture46 = @prefecture46
+
+
+    # messageページのルーム表示用記述
+    @current_user = current_user
+    @current_entries = @current_user.entries
+    myroom = []
+
+    # current_userのroom.idを格納
+    @current_entries.each do |entry|
+      myroom << entry.room.id
+    end
+
+    # current_userと相手側のユーザーが格納されているレコードを探す処理
+    @another_entries = Entry.where(room_id: myroom).where.not(user_id: @current_user.id)
+    @new_entries = @another_entries.order(created_at: :desc)
+    
   end
 
   def edit

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -1,2 +1,3 @@
 module RoomsHelper
+  
 end

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,0 +1,23 @@
+<div class="userPostIndex">
+  <h6 class="blockquote follow"> 
+    <blockquote>
+      メッセージ一覧
+    </blockquote>
+  </h6>
+  <% @new_entries.each do |e| %>
+    <%= link_to room_path(e.room.id) do %>
+      <div class='mypage-NewPost'>
+        <div class='indexUserInfomation'>
+          <div class='indexUserInfomation__userAvater'>
+            <%= image_tag e.user.image.url, class: "avater" %>
+          </div>
+          <span class='indexUserInfomation__username'>
+            <a href="/users/<%= e.user.id %>">
+              <%= e.user.name %>
+            </a>
+          </span>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -6,7 +6,7 @@
       </h4>
       <%# ユーザーのアイコンと名前表示 %>
       <div class="roomsUsers">
-        <% @entries.each do |e| %>
+        <% @entries.each_with_index do |e, i| %>
           <div class="roomsUsersInfo">
             <div class="roomsUsersNav">
             <%= link_to '', user_path(e.user_id), class: "roomUserLink", method: :get %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,6 +77,13 @@
             Bookmark
           </a>
         </li>
+        <% if user_signed_in? && current_user.id == @user.id %>
+          <li>
+            <a href="#" id="post", class='user-nav'>
+              message
+            </a>
+          </li>
+        <% end %>
       </ul>
       <ul class="pages">
         <li class="page show">
@@ -122,7 +129,7 @@
                     <%= @user.followers.count %> 人
                   </li>
                   <li class="top-page__status__sentence__counts__content">
-                    <%= @posts.length %> 件
+                    <%= @user.posts.all.count %> 件
                   </li>
                   <li class="top-page__status__sentence__counts__content">
                     <%= @user.cliped_posts.length %> 件
@@ -165,10 +172,15 @@
               投稿がまだありません。
             </div>
           <% else %>
+            <h4>
+              <blockquote>
+                <i class="fas fa-pen"></i>
+                <span class="userPostIndex__postCount">
+                  POST :  <%= @user.posts.all.count %> 件
+                </span>
+              </blockquote>
+            </h4>
             <div class="userPostIndex">
-              <div class="userPostIndex__postCount">
-                POST :  <%= @user.posts.all.count %> 件
-              </div>
               <div id="mypostPagenate">
                 <% @posts.each do |post| %>
                   <div class='mypage-NewPost'>
@@ -213,10 +225,15 @@
               Bookmarkした投稿がまだありません。
             </div>
           <% else %>
+            <h4>
+              <blockquote>
+                <i class="fas fa-bookmark"></i>
+                <span class="userPostIndex__postCount">
+                  Bookmark :  <%= @user.cliped_posts.all.count %> 件
+                </span>
+              </blockquote>
+            </h4>
             <div class="userPostIndex">
-              <div class="userPostIndex__postCount">
-                Bookmark :  <%= @user.cliped_posts.all.count %> 件
-              </div>
               <div id="mybookmarkPagenate">
                 <% @bookmarks.each do |post| %>
                   <div class='mypage-NewPost'>
@@ -262,6 +279,43 @@
               </div>
             </div>
           <% end %>
+        </li>
+        <%# messageページ %>
+        <li class="page">
+          <div class="userPostIndex">
+            <div class="directMessageUsers">
+              <div class="notification">
+                <h6 class="blockquote follow"> 
+                  <blockquote>
+                    <i class="fas fa-envelope"></i>
+                    メッセージ一覧
+                  </blockquote>
+                </h6>
+                <% @new_entries.each do |e| %>
+                  <div class="dmUserBox">
+                    <%= link_to '', room_path(e.room.id), class: "showlink", method: :get %>
+                    <div class='dmUserInfomation'>
+                      <div class='dmUserInfomation__userAvater'>
+                        <%= image_tag e.user.image.url, class: "avater" %>
+                      </div>
+                      <span class='dmUserInfomation__username'>
+                        <%= link_to e.user.name, user_path(e.user_id), class: "dmUserName" %>
+                      </span>
+                    </div>
+                    <span class="lastMessage">
+                      <%= Message.find_by(id: e.room.message_ids.last).message %>
+                      <span class='lastMessageUserName'>
+                        by <%= Message.find_by(id: e.room.message_ids.last).user.name %>
+                      </span>
+                    </span>
+                    <span class="lastMessageDate">
+                      <%= Message.find_by(id: e.room.message_ids.last).created_at.strftime("%Y-%m-%d %H:%M") %>
+                    </span>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
         </li>
       </ul>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module MyTown
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.i18n.default_locale = :ja #デフォルト言語の日本語化
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
ユーザーマイページにDMユーザー一覧ページ（Messageページ）を作成する。なお、Messageページはログインユーザーかつカレントユーザーのみ表示させるように条件分岐を行う。

# Why
DMでのやりとりを今まで以上にスムーズにさせるため。
プライバシー保護の観点から自分だけがDMユーザー一覧ページを見えるようにするため。