### PR TITLE
[add]showpage-comment-submitBtn-disabled-prop-add

### DIFF
--- a/app/assets/javascript/comment.js
+++ b/app/assets/javascript/comment.js
@@ -1,3 +1,4 @@
+// コメント送信の非同期通信化============================================================
 $(function() {
   function buildHTML(comment) {
     let html = `<div class="comment">
@@ -26,10 +27,39 @@ $(function() {
       let html = buildHTML(data);
       $('.comments').prepend(html);
       $('.commentForm__textbox').val('');
-      $('.commentForm__btn').prop('disabled', false);
+      $('.commentForm__btn').prop('disabled', true);
     })
     .fail(function(){
       alert('error');
     })
   })
+});
+
+// コメントフォームの入力があるまで送信ボタンを無効化=====================================
+//バリデーション
+
+
+// ==============================================================================
+$(function() {
+  //最初に送信ボタンを無効にする
+  // $('#commentSendBtn').prop("disabled", true);
+  $('#commentSendBtn').prop("disabled", true);
+
+  $('#commentInput').keyup(function () {
+    let send = false;
+    const chatComment = $(this).val().replace(/^\s+/, "");
+    if (chatComment.length > 0) {
+      send = true;
+    }
+    //フォームが全て埋まっていたら(send = trueの場合)
+    if (send) {
+      //送信ボタンを有効にする
+      $('#commentSendBtn').prop("disabled", false);
+    }
+    // フォームが一つでも空だったら(send = falseの場合)
+    else {
+        //送信ボタンを無効にする
+        $('#commentSendBtn').prop("disabled", true);
+    }
+  });
 });

--- a/app/assets/stylesheets/comment/comment.scss
+++ b/app/assets/stylesheets/comment/comment.scss
@@ -42,6 +42,10 @@
   .commentForm__btn:hover {
     background-color: #00bfff;
   }
+  .commentForm__btn[disabled] {
+    background-color: #ddd;
+    cursor: not-allowed;
+  }
 }
 
 .commentArea h3 {
@@ -54,8 +58,10 @@
 
 .comments {
   padding: 5px;
+  height: 31vh;
   width: 30vw;
   margin: 0 auto;
+  overflow: scroll;
 }
 
 .comment {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -96,8 +96,8 @@
   <% if current_user %>
     <div class="commentForm">
       <%= form_with(model: [@post, @comment], local: true, id: "new_comment") do |form| %>
-        <%= form.text_area :text, placeholder: "コメントする", rows: "2", class: "commentForm__textbox" %>
-        <%= form.submit "SEND", class: "commentForm__btn" %>
+        <%= form.text_area :text, placeholder: "コメントする", rows: "2", class: "commentForm__textbox", id: "commentInput" %>
+        <%= form.submit "SEND", class: "commentForm__btn", id: "commentSendBtn" %>
       <% end %>
     </div>
   <% else %>


### PR DESCRIPTION
# What
showページのコメント送信ボタンをフォームが入力されるまで、disabled属性を付与して無効化する。
（フォームが入力されると有効化になる）